### PR TITLE
modify syntax for headers

### DIFF
--- a/display.h
+++ b/display.h
@@ -3,10 +3,10 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
-void plot( screen s, color c, int x, int y);
-void clear_screen( screen s);
-void save_ppm( screen s, char *file);
-void save_extension( screen s, char *file);
-void display( screen s);
+void plot(screen, color, int, int);
+void clear_screen(screen);
+void save_ppm(screen, char *);
+void save_extension(screen, char *);
+void display(screen);
 
 #endif


### PR DESCRIPTION
I didn't add or remove any arguments; I just took out the name and left the type for each of the arguments to try to see if this would make GitHub stop designating display.h as C++ code.